### PR TITLE
La til en tom variabel i tilfeller der det ikke er progress

### DIFF
--- a/app/pages/min_side_player.php
+++ b/app/pages/min_side_player.php
@@ -715,6 +715,7 @@ a.status_venter:hover { }
 				
 				// fremdrift
 				$progress = '';
+				$progress_text = '';
 				$item = new achievement_player_item(page_min_side::$active_player, $a);
 				$item->load_active();
 				if ($p = $item->get_progress())


### PR DESCRIPTION
La til en tom variabel i tilfeller der det ikke er progress. Slik at vi ikke får feil for undefined variable.