### PR TITLE
Fix av visningsfeil av poeng under rankeoppdrag

### DIFF
--- a/app/extra/class.oppdrag.php
+++ b/app/extra/class.oppdrag.php
@@ -1482,8 +1482,8 @@ class oppdrag
 		{
 			case "rank_points":
 				// oppnå poeng på gitt tid
-				$target = $this->up->data['up_points']+$params->get("points");
-				return $prefix.'<p>Oppnå totalt '.game::format_num($target).' poeng i løpet av '.game::timespan($time_limit, game::TIME_FULL).'. <span class="dark">Merk at <i>lotto</i> og <i>angrep</i> ikke teller med. Hvis du mottar poeng fra disse funksjonene vil poenggrensen øke med så mange poeng du mottar.</span></p>'.$suffix;
+				$target = $params->get("points");
+				return $prefix.'<p>Oppnå '.game::format_num($target).' poeng i løpet av '.game::timespan($time_limit, game::TIME_FULL).'. <span class="dark">Merk at <i>lotto</i> og <i>angrep</i> ikke teller med. Hvis du mottar poeng fra disse funksjonene vil poenggrensen øke med så mange poeng du mottar.</span></p>'.$suffix;
 			break;
 			
 			case "kriminalitet_different":


### PR DESCRIPTION
Endret fra "Oppnå totalt 553 977 poeng i løpet av 30 minutter." til Oppnå 400 poeng i løpet av 30 minutter.".
Se issue #196 