### PR TITLE
Set the ff->competition variable to false after the competition is won

### DIFF
--- a/app/extra/class.ff.php
+++ b/app/extra/class.ff.php
@@ -2134,6 +2134,7 @@ class ff
 		$this->data['ff_pay_points'] = 0;
 		
 		$this->data['fff_active'] = 0;
+		$this->competition = false;
 		
 		// send melding til boss og underboss
 		for ($i = 1; $i <= 2; $i++)


### PR DESCRIPTION
Earlier the handler for the Capofamiglia achievement was canceled because the ff->competition variable was still true. 
Fixes #12 